### PR TITLE
Add SetLogger test coverage (86.6% → 89.6%)

### DIFF
--- a/di/container_test.go
+++ b/di/container_test.go
@@ -2,8 +2,12 @@ package di
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"sync/atomic"
 	"testing"
+
+	dilogger "github.com/lcrux/go-di/di/di-logger"
 )
 
 type depA struct {
@@ -190,6 +194,61 @@ func TestContainer_Shutdown_CanceledContextSkipsLifecycleEnd(t *testing.T) {
 	}
 	if called != 0 {
 		t.Fatalf("expected EndLifecycle not to be called, got %d", called)
+	}
+}
+
+type errSetLoggerContext struct {
+	id string
+}
+
+func (e *errSetLoggerContext) ID() string                                    { return e.id }
+func (e *errSetLoggerContext) IsClosed() bool                                { return false }
+func (e *errSetLoggerContext) Shutdown(...context.Context) []error           { return nil }
+func (e *errSetLoggerContext) GetInstance(string) (reflect.Value, bool)      { return reflect.Value{}, false }
+func (e *errSetLoggerContext) SetInstance(string, reflect.Value) error       { return nil }
+func (e *errSetLoggerContext) SetLogger(_ dilogger.Logger) error {
+	return fmt.Errorf("mock SetLogger error")
+}
+
+func TestContainer_SetLogger_RejectsNil(t *testing.T) {
+	c := NewContainer()
+	if err := c.SetLogger(nil); err == nil {
+		t.Fatal("expected error when setting nil logger")
+	}
+}
+
+func TestContainer_SetLogger_SetsLoggerWithNoAdditionalContexts(t *testing.T) {
+	c := NewContainer()
+	logger := dilogger.NewLogger(nil)
+	if err := c.SetLogger(logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestContainer_SetLogger_PropagatestoExistingContexts(t *testing.T) {
+	c := NewContainer()
+	_ = c.NewContext()
+	var debugLogged bool
+	logger := dilogger.NewLogger(func(o *dilogger.LoggerOptions) {
+		o.LogLevel = dilogger.Debug
+		o.Debug = func(_ string, _ ...interface{}) { debugLogged = true }
+	})
+	if err := c.SetLogger(logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !debugLogged {
+		t.Fatal("expected logger to be propagated to existing contexts and log")
+	}
+}
+
+func TestContainer_SetLogger_PropagatesErrorFromContext(t *testing.T) {
+	c := NewContainer()
+	impl := c.(*containerImpl)
+	impl.lifecycleContexts.Set("mock-key", &errSetLoggerContext{id: "mock-ctx-id"})
+
+	logger := dilogger.NewLogger(nil)
+	if err := c.SetLogger(logger); err == nil {
+		t.Fatal("expected error when context SetLogger fails")
 	}
 }
 

--- a/di/lifecycle_context_test.go
+++ b/di/lifecycle_context_test.go
@@ -3,10 +3,12 @@ package di
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync/atomic"
 	"testing"
 
+	dilogger "github.com/lcrux/go-di/di/di-logger"
 	diutils "github.com/lcrux/go-di/di/di-utils"
 )
 
@@ -172,6 +174,31 @@ func TestLifecycleContext_Shutdown_EmptyContext(t *testing.T) {
 	errs := ctx.Shutdown()
 	if len(errs) != 0 {
 		t.Fatalf("Expected no errors, got %d", len(errs))
+	}
+}
+
+func TestLifecycleContext_SetLogger_RejectsNil(t *testing.T) {
+	ctx := NewLifecycleContext()
+	err := ctx.SetLogger(nil)
+	if err == nil {
+		t.Fatal("expected error when setting nil logger")
+	}
+}
+
+func TestLifecycleContext_SetLogger_SetsLogger(t *testing.T) {
+	ctx := NewLifecycleContext()
+	var logged string
+	logger := dilogger.NewLogger(func(o *dilogger.LoggerOptions) {
+		o.LogLevel = dilogger.Debug
+		o.Debug = func(format string, v ...interface{}) {
+			logged = fmt.Sprintf(format, v...)
+		}
+	})
+	if err := ctx.SetLogger(logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logged == "" {
+		t.Fatal("expected debug log message after setting logger")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add 6 tests covering `SetLogger` on both `containerImpl` and `lifecycleContextImpl`
- Both `SetLogger` methods now at **100%** coverage
- Overall `di` package coverage: **86.6% → 89.6%**

## Test cases

- `TestLifecycleContext_SetLogger_RejectsNil` — nil logger returns error
- `TestLifecycleContext_SetLogger_SetsLogger` — valid logger is applied and emits debug log
- `TestContainer_SetLogger_RejectsNil` — nil logger returns error
- `TestContainer_SetLogger_SetsLoggerWithNoAdditionalContexts` — succeeds with no extra contexts
- `TestContainer_SetLogger_PropagatestoExistingContexts` — logger is forwarded to all existing contexts
- `TestContainer_SetLogger_PropagatesErrorFromContext` — error from a context's SetLogger is surfaced

## Test plan

- [x] `go test ./di/... -coverprofile=coverage.out` passes with no failures
- [x] `SetLogger` on both types reports 100% in `go tool cover -func`