### PR TITLE
Add persistInstance tests for 100% branch coverage

### DIFF
--- a/di/container_test.go
+++ b/di/container_test.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"context"
+	"reflect"
 	"sync/atomic"
 	"testing"
 )
@@ -190,6 +191,45 @@ func TestContainer_Shutdown_CanceledContextSkipsLifecycleEnd(t *testing.T) {
 	}
 	if called != 0 {
 		t.Fatalf("expected EndLifecycle not to be called, got %d", called)
+	}
+}
+
+func TestPersistInstance_Scoped_NilCtx_FallsBackToBackground(t *testing.T) {
+	c := NewContainer()
+	impl := c.(*containerImpl)
+	entry := &containerEntry{scope: Scoped, key: "test-nil-ctx-key"}
+	instance := reflect.ValueOf(&depA{name: "a"})
+
+	if err := impl.persistInstance(nil, entry, instance); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := c.BackgroundContext().GetInstance("test-nil-ctx-key"); !ok {
+		t.Fatal("expected instance stored in background context when ctx is nil")
+	}
+}
+
+func TestPersistInstance_Singleton_ErrorOnClosedBackgroundContext(t *testing.T) {
+	c := NewContainer()
+	if err := Register[*depA](c, Singleton, func() *depA { return &depA{name: "a"} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+	c.BackgroundContext().Shutdown()
+
+	if _, err := Resolve[*depA](c, nil); err == nil {
+		t.Fatal("expected error resolving Singleton into closed background context")
+	}
+}
+
+func TestPersistInstance_Scoped_ErrorOnClosedContext(t *testing.T) {
+	c := NewContainer()
+	if err := Register[*depA](c, Scoped, func() *depA { return &depA{name: "a"} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+	ctx := c.NewContext()
+	ctx.Shutdown()
+
+	if _, err := Resolve[*depA](c, ctx); err == nil {
+		t.Fatal("expected error resolving Scoped service into closed lifecycle context")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds 3 tests covering all previously untested branches in `persistInstance`
- `persistInstance` now at **100%** coverage
- `di` package coverage: **87.6% → 89.7%**

## What was missing

| Branch | Why it was uncovered |
|---|---|
| Scoped with nil ctx → background fallback | Unreachable via public API (`resolveContext` fills nil first); tested by calling `persistInstance` directly |
| Singleton error (closed background context) | Close `BackgroundContext()` before resolving, triggering `SetInstance` error |
| Scoped error (closed lifecycle context) | Shut down the scoped context before resolving into it |

## Test plan

- [x] `go test ./di/... -coverprofile=coverage.out` passes with no failures
- [x] `persistInstance` reports 100% in `go tool cover -func`