### PR TITLE
Add MustResolveWithKey success path test for 100% coverage

### DIFF
--- a/di/resolver_test.go
+++ b/di/resolver_test.go
@@ -394,6 +394,20 @@ func TestMustResolveWithKey_PanicsOnResolveError(t *testing.T) {
 	_ = MustResolveWithKey[*depA](c, "missing.key", nil)
 }
 
+func TestMustResolveWithKey_Succeeds(t *testing.T) {
+	c := NewContainer()
+	ctx := c.NewContext()
+
+	if err := RegisterWithKey[*depA](c, "custom.key", Transient, func() *depA { return &depA{name: "ok"} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+
+	instance := MustResolveWithKey[*depA](c, "custom.key", ctx)
+	if instance == nil || instance.name != "ok" {
+		t.Fatal("expected to resolve instance by custom key")
+	}
+}
+
 func TestMustResolve_Succeeds(t *testing.T) {
 	c := NewContainer()
 	ctx := c.NewContext()


### PR DESCRIPTION
## Summary

- Adds `TestMustResolveWithKey_Succeeds` — the only missing test
- `MustResolveWithKey` now at **100%** coverage

## What was missing

The panic paths (`empty key`, `resolve error`) were already tested, but the `return instance` success path had no test. `MustResolve_Succeeds` only exercised `MustResolve`, not `MustResolveWithKey`.

## Test plan

- [x] `go test ./di/... -coverprofile=coverage.out` passes with no failures
- [x] `MustResolveWithKey` reports 100% in `go tool cover -func`