### PR TITLE
Bring di-logger to 100% test coverage

### DIFF
--- a/di/di-logger/logger.go
+++ b/di/di-logger/logger.go
@@ -19,7 +19,11 @@ const (
 var defaultLogLevel LogLevel
 
 func init() {
-	envLogLevel := strings.ToUpper(strings.TrimSpace(os.Getenv("GODI_LOG_LEVEL")))
+	initLogLevel(os.Getenv("GODI_LOG_LEVEL"))
+}
+
+func initLogLevel(envLogLevel string) {
+	envLogLevel = strings.ToUpper(strings.TrimSpace(envLogLevel))
 	switch envLogLevel {
 	case "INFO":
 		defaultLogLevel = Info

--- a/di/di-logger/logger_test.go
+++ b/di/di-logger/logger_test.go
@@ -1,7 +1,9 @@
 package dilogger
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"testing"
@@ -154,3 +156,137 @@ func TestLoggerImpl_SpecialCharacters(t *testing.T) {
 		t.Fatalf("Expected '%s', got '%s'", message, got)
 	}
 }
+
+func TestIsLoggerFunc_NilInterfaceReturnsFalse(t *testing.T) {
+	if isLoggerFunc(nil) {
+		t.Fatal("expected false for nil interface")
+	}
+}
+
+func TestWarnf_EarlyReturn_WhenLogLevelIsError(t *testing.T) {
+	called := false
+	l := &loggerImpl{options: &LoggerOptions{
+		LogLevel: Error,
+		Warn:     func(_ string, _ ...interface{}) { called = true },
+	}}
+	l.Warnf("should be silenced")
+	if called {
+		t.Fatal("expected Warnf to return early at Error log level")
+	}
+}
+
+func TestErrorf_EarlyReturn_WhenLogLevelAboveError(t *testing.T) {
+	called := false
+	l := &loggerImpl{options: &LoggerOptions{
+		LogLevel: LogLevel(4),
+		Error:    func(_ string, _ ...interface{}) { called = true },
+	}}
+	l.Errorf("should be silenced")
+	if called {
+		t.Fatal("expected Errorf to return early when log level is above Error")
+	}
+}
+
+func TestDefaultInfoLogger_UsedWhenNoCustomFunc(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	logger := NewLogger(func(o *LoggerOptions) { o.LogLevel = Info })
+	logger.Infof("hello info")
+
+	if !strings.Contains(buf.String(), "hello info") {
+		t.Fatalf("expected default info logger output, got: %s", buf.String())
+	}
+}
+
+func TestDefaultDebugLogger_UsedWhenNoCustomFunc(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	logger := NewLogger(func(o *LoggerOptions) { o.LogLevel = Debug })
+	logger.Debugf("hello debug")
+
+	if !strings.Contains(buf.String(), "hello debug") {
+		t.Fatalf("expected default debug logger output, got: %s", buf.String())
+	}
+}
+
+func TestDefaultWarnLogger_UsedWhenNoCustomFunc(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	logger := NewLogger(func(o *LoggerOptions) { o.LogLevel = Warn })
+	logger.Warnf("hello warn")
+
+	if !strings.Contains(buf.String(), "hello warn") {
+		t.Fatalf("expected default warn logger output, got: %s", buf.String())
+	}
+}
+
+func TestDefaultErrorLogger_UsedWhenNoCustomFunc(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	logger := NewLogger(func(o *LoggerOptions) { o.LogLevel = Error })
+	logger.Errorf("hello error")
+
+	if !strings.Contains(buf.String(), "hello error") {
+		t.Fatalf("expected default error logger output, got: %s", buf.String())
+	}
+}
+
+func TestInitLogLevel_Unknown_DefaultsToErrorAndLogs(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	initLogLevel("INVALID")
+	if defaultLogLevel != Error {
+		t.Fatalf("expected Error for unknown level, got %d", defaultLogLevel)
+	}
+}
+
+func TestInitLogLevel_Info(t *testing.T) {
+	initLogLevel("info")
+	if defaultLogLevel != Info {
+		t.Fatalf("expected Info, got %d", defaultLogLevel)
+	}
+}
+
+func TestInitLogLevel_Debug(t *testing.T) {
+	initLogLevel("debug")
+	if defaultLogLevel != Debug {
+		t.Fatalf("expected Debug, got %d", defaultLogLevel)
+	}
+}
+
+func TestInitLogLevel_Warn(t *testing.T) {
+	initLogLevel("WARN")
+	if defaultLogLevel != Warn {
+		t.Fatalf("expected Warn, got %d", defaultLogLevel)
+	}
+}
+
+func TestInitLogLevel_Error(t *testing.T) {
+	initLogLevel("ERROR")
+	if defaultLogLevel != Error {
+		t.Fatalf("expected Error, got %d", defaultLogLevel)
+	}
+}
+
+func TestInitLogLevel_Empty_DefaultsToError(t *testing.T) {
+	initLogLevel("")
+	if defaultLogLevel != Error {
+		t.Fatalf("expected Error for empty string, got %d", defaultLogLevel)
+	}
+}
+


### PR DESCRIPTION
## Summary

- `di-logger` package: **79.7% → 100%** across all 13 functions

## What was missing and how it's fixed

| Function | Was | Fix |
|---|---|---|
| `init` | 44.4% | Extracted `initLogLevel(string)` — `init()` can't be re-entered, so the env-var logic is tested via the extracted function |
| `isLoggerFunc` | 75% | Added test calling `isLoggerFunc(nil)` directly — typed nil `LoggerFunc` fields never produce a nil interface through `buildLoggerOptions` |
| `Warnf` | 83.3% | Test with `LogLevel=Error` triggers the early-return branch |
| `Errorf` | 83.3% | Test with `LogLevel(4)` (above max enum value) via direct `loggerImpl` construction |
| `defaultInfoLogger` | 0% | Logger without custom Info func at `LogLevel=Info` falls through to the default |
| `defaultDebugLogger` | 0% | Same pattern at `LogLevel=Debug` |
| `defaultWarnLogger` | 0% | Same pattern at `LogLevel=Warn` |
| `defaultErrorLogger` | 0% | Same pattern at `LogLevel=Error` |

## Test plan

- [x] `go test ./di/di-logger/... -coverprofile=... -count=1` passes with no failures
- [x] Every function in `go tool cover -func` reports 100%
- [x] `log.SetOutput` is restored after each test using saved original writer