### PR TITLE
fix: data race on dependencyTreeCache in getDependencyTree (#39)

### DIFF
--- a/di/container.go
+++ b/di/container.go
@@ -342,8 +342,13 @@ func (c *containerImpl) resolveEntryWithDeps(
 // It detects circular dependencies and returns an error if any are found.
 func (c *containerImpl) getDependencyTree(key string) ([]*containerEntry, error) {
 
-	if entry, exists := c.registry.Get(key); exists && entry.dependencyTreeCache != nil {
-		return entry.dependencyTreeCache, nil
+	if entry, exists := c.registry.Get(key); exists {
+		entry.mutex.Lock()
+		cached := entry.dependencyTreeCache
+		entry.mutex.Unlock()
+		if cached != nil {
+			return cached, nil
+		}
 	}
 	seen := make(map[*containerEntry]bool)
 	visiting := make(map[*containerEntry]bool)
@@ -400,7 +405,9 @@ func (c *containerImpl) getDependencyTree(key string) ([]*containerEntry, error)
 	}
 
 	if entry, exists := c.registry.Get(key); exists {
+		entry.mutex.Lock()
 		entry.dependencyTreeCache = order
+		entry.mutex.Unlock()
 	}
 
 	return order, nil

--- a/di/container_test.go
+++ b/di/container_test.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -205,4 +206,38 @@ func TestContainer_Validate_IgnoresContainerAndContextDependencies(t *testing.T)
 	if err := c.Validate(); err != nil {
 		t.Fatalf("expected validation to ignore container and context dependencies, got: %v", err)
 	}
+}
+
+// TestContainer_getDependencyTree_NoDataRace verifies that concurrent calls to getDependencyTree
+// for the same key do not cause a data race on dependencyTreeCache.
+func TestContainer_getDependencyTree_NoDataRace(t *testing.T) {
+	c := NewContainer()
+
+	if err := Register[*depA](c, Transient, func() *depA { return &depA{name: "a"} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+	if err := Register[*depB](c, Transient, func() *depB { return &depB{name: "b"} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+	if err := Register[*depC](c, Transient, func(a *depA, b *depB) *depC { return &depC{a: a, b: b} }); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := Resolve[*depC](c, nil); err != nil {
+				t.Errorf("unexpected resolve error: %v", err)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

- `getDependencyTree` read and wrote `entry.dependencyTreeCache` without synchronization, creating a data race when two goroutines raced on the same key
- Fixed by locking `entry.mutex` around both the cache read (early-return check) and the cache write after the tree is computed
- Added `TestContainer_getDependencyTree_NoDataRace` which fans out 50 goroutines all resolving the same key simultaneously; the test fails with `-race` before the fix and passes after

## Changes

- **`di/container.go`**: wrap the `dependencyTreeCache` read and write in `entry.mutex.Lock/Unlock` — no other logic changed
- **`di/container_test.go`**: new concurrent race-detection test

## Test plan

- [ ] `go test github.com/lcrux/go-di/di -race -count=5` passes with no data race reported
- [ ] All existing tests continue to pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)