### PR TITLE
fix: nil panic window when resetting lifecycle contexts in Shutdown (#41)

### DIFF
--- a/di/container.go
+++ b/di/container.go
@@ -88,7 +88,10 @@ func (c *containerImpl) SetLogger(logger dilogger.Logger) error {
 
 // BackgroundContext returns the background lifecycle context.
 func (c *containerImpl) BackgroundContext() LifecycleContext {
-	if value, exists := c.lifecycleContexts.Get(backgroundContextKey); exists {
+	c.mutex.RLock()
+	lc := c.lifecycleContexts
+	c.mutex.RUnlock()
+	if value, exists := lc.Get(backgroundContextKey); exists {
 		return value
 	}
 	return nil
@@ -171,9 +174,14 @@ func (c *containerImpl) Shutdown(ctxs ...context.Context) []error {
 	wg.Wait()
 
 	if !checkIfCanceled(ctx) {
-		// Reset the lifecycle contexts after shutdown, keeps a clean background context to avoid nil references
-		c.lifecycleContexts = diutils.NewAsyncMap[string, LifecycleContext]()
-		c.lifecycleContexts.Set(backgroundContextKey, NewLifecycleContext())
+		// Reset the lifecycle contexts after shutdown, keeps a clean background context to avoid nil references.
+		// Build the new map with the background context already present before swapping it in, so that
+		// a concurrent Resolve() call can never observe a window where BackgroundContext() returns nil.
+		newLifecycleContexts := diutils.NewAsyncMap[string, LifecycleContext]()
+		newLifecycleContexts.Set(backgroundContextKey, NewLifecycleContext())
+		c.mutex.Lock()
+		c.lifecycleContexts = newLifecycleContexts
+		c.mutex.Unlock()
 	}
 
 	return errors

--- a/di/container_test.go
+++ b/di/container_test.go
@@ -2,6 +2,7 @@ package di
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
@@ -190,6 +191,45 @@ func TestContainer_Shutdown_CanceledContextSkipsLifecycleEnd(t *testing.T) {
 	}
 	if called != 0 {
 		t.Fatalf("expected EndLifecycle not to be called, got %d", called)
+	}
+}
+
+// TestContainer_Shutdown_ConcurrentResolveNoPanic reproduces the nil-background-context window
+// described in issue #41: a concurrent Resolve during Shutdown could call BackgroundContext()
+// in the brief gap after the old map was replaced but before the new background context was set,
+// receiving nil and then panicking in loadInstance.
+func TestContainer_Shutdown_ConcurrentResolveNoPanic(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		c := NewContainer()
+
+		if err := Register[*depA](c, Singleton, func() *depA { return &depA{name: "a"} }); err != nil {
+			t.Fatalf("unexpected register error: %v", err)
+		}
+
+		// Pre-warm the dependency tree cache to avoid the pre-existing dependencyTreeCache data race.
+		if _, err := Resolve[*depA](c, nil); err != nil {
+			t.Fatalf("unexpected resolve error during warm-up: %v", err)
+		}
+
+		// Spin up many goroutines calling Resolve concurrently with Shutdown so that at least
+		// one is likely to hit the window between the map replacement and the Set call.
+		var wg sync.WaitGroup
+		for j := 0; j < 20; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Ignore errors — the service may not resolve after shutdown; what matters is no panic.
+				_, _ = Resolve[*depA](c, nil)
+			}()
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Shutdown()
+		}()
+
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes issue #41: concurrent `Resolve()` could panic with a nil pointer dereference during `Shutdown()` because `BackgroundContext()` returned `nil` in the brief window after the old `lifecycleContexts` map was replaced but before the new background context was set.
- Eliminates the nil window by building the replacement `AsyncMap` with the background context already present, then atomically swapping it in under `c.mutex.Lock()`.
- Guards the field read in `BackgroundContext()` with `c.mutex.RLock()` so the swap and the read are properly synchronized, eliminating the data race detected by `-race`.
- Adds `TestContainer_Shutdown_ConcurrentResolveNoPanic` which hammers concurrent `Resolve()`+`Shutdown()` (100 iterations × 20 goroutines) to confirm no panic and no race.

## Test plan

- [ ] `go test ./di -race -count=1` passes with no race warnings
- [ ] `TestContainer_Shutdown_ConcurrentResolveNoPanic` passes consistently
- [ ] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)